### PR TITLE
Fixups & improvements

### DIFF
--- a/orbitos-amd64-hvm.yml
+++ b/orbitos-amd64-hvm.yml
@@ -1,10 +1,10 @@
 ---
-name: debian-{system.release}-{system.architecture}-{provider.virtualization}-{%Y}-{%m}-{%d}-ebs
+name: orbit-os-{system.release}-{system.architecture}-{provider.virtualization}-{%Y}-{%m}-{%d}-ebs
 provider:
   name: ec2
   virtualization: hvm
   enhanced_networking: simple
-  description: Debian {system.release} {system.architecture}
+  description: Orbit OS -- Debian {system.release} {system.architecture}
 bootstrapper:
   workspace: ./build
   tarball: true

--- a/orbitos-amd64-hvm.yml
+++ b/orbitos-amd64-hvm.yml
@@ -13,6 +13,7 @@ packages:
     # System utilities
     - apt-listbugs
     - apt-listchanges
+    - apt-transport-https
     - aptitude
     - ca-certificates
     - debian-goodies
@@ -42,10 +43,10 @@ packages:
     - fleet
 
   install_standard: false
-  mirror: http://cloudfront.debian.net/debian
+  mirror: https://cloudfront.debian.net/debian
   sources:
     sid:
-      - deb http://mirrors.kernel.org/debian/ unstable main
+      - deb https://cloudfront.debian.net/debian sid main
   preferences:
     main:
       - package: "*"
@@ -53,7 +54,8 @@ packages:
         pin-priority: 800
       - package: fleet etcd
         pin: release o=Debian, n=sid
-        pin-priority: 840 
+        pin-priority: 840
+
 system:
   release: jessie
   architecture: amd64
@@ -68,8 +70,7 @@ volume:
     root:
       filesystem: ext4
       size: 8GiB
-packages:
-  mirror: http://cloudfront.debian.net/debian
+
 plugins:
   cloud_init:
     metadata_sources: Ec2

--- a/orbitos-amd64-hvm.yml
+++ b/orbitos-amd64-hvm.yml
@@ -10,9 +10,34 @@ bootstrapper:
   tarball: true
 packages:
   install:
+    # System utilities
+    - apt-listbugs
+    - apt-listchanges
+    - aptitude
+    - ca-certificates
+    - debian-goodies
+    - dstat
+    - file
     - htop
+    - less
+    - lsof
+    - mtr-tiny
+    - openntpd
+    - psmisc
     - strace
+    - sudo
     - sysdig
+    - task-ssh-server
+    - tcpdump
+    - tmux
+    - unp
+
+    # Haveged, the entropy gathering deamon
+    # NOTE: It is unclear how good this is in VMs.
+    #       Is there a way to get entropy from the hypervisor?
+    - haveged
+
+    # Orchestration
     - etcd
     - fleet
 

--- a/orbitos-amd64-hvm.yml
+++ b/orbitos-amd64-hvm.yml
@@ -15,7 +15,8 @@ packages:
     - sysdig
     - etcd
     - fleet
-  install_standard: true
+
+  install_standard: false
   mirror: http://cloudfront.debian.net/debian
   sources:
     sid:


### PR DESCRIPTION
- Gives a different image name, not to confuse with the official Debian images.
- Replaces Debian's “standard system utilities” (which contain NFS ...) with our own.
- Systematically uses the `cloudfront.debian.net` mirror, over HTTPS.
- Removes a spurious `packages` section.
